### PR TITLE
chore: update deployment script

### DIFF
--- a/contracts/deployment-config/ECDSAConsumer.json
+++ b/contracts/deployment-config/ECDSAConsumer.json
@@ -1,3 +1,0 @@
-{
-    "keystoreValidator": "0x58080a5dad6E894969fD8afE08D8C272032B3004"
-}

--- a/contracts/script/ECDSAConsumer.s.sol
+++ b/contracts/script/ECDSAConsumer.s.sol
@@ -39,13 +39,7 @@ contract ECDSAConsumerScript is Script {
         }
     }
 
-    function run() external broadcast {
-        string memory config = vm.readFile(configPath);
-
-        IKeystoreValidator validator = IKeystoreValidator(config.readAddress(".keystoreValidator"));
-        validator.deployAndRegisterKeyDataConsumer(type(ECDSAConsumer).creationCode);
-
-        console.log("Consumer creation codehash");
-        console2.logBytes32(keccak256(type(ECDSAConsumer).creationCode));
+    function run() external broadcast returns (ECDSAConsumer consumer) {
+        consumer = new ECDSAConsumer();
     }
 }


### PR DESCRIPTION
Consumer deployment no longer depends on the keystore validator deployment